### PR TITLE
feat(ci): Create CI job to build and publish container image

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,0 +1,33 @@
+name: Publish Docker image
+on:
+  push:
+    branches:
+      - master
+jobs:
+  push_to_registries:
+    name: Push Docker image to multiple registries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: |
+            theinfinitytimes/theinfinitytimes:latest
+            ghcr.io/theinfinitytimes/theinfinitytimes:latest


### PR DESCRIPTION
This creates a pipeline that builds and publishes a container image to docker hub and github packages.
The pipeline should only run on the master branch and push the `latest` tag. 
