### PR TITLE
Optimize docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+dist/
+.github/
+node_modules/
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
-FROM node:lts
+FROM node:lts as builder
 
 RUN mkdir /theinfinitytimes
-COPY ./package.json /theinfinitytimes
-WORKDIR theinfinitytimes
+WORKDIR /theinfinitytimes
+COPY ./package.json ./package-lock.json ./
 
-RUN npm install
+RUN npm ci
 
 COPY . /theinfinitytimes
 WORKDIR /theinfinitytimes
 
 RUN npm run build
 
-CMD npm run start:prod
+FROM nginx:stable-alpine AS production
+COPY --from=builder /theinfinitytimes/dist/theinfinitytimes/ /usr/share/nginx/html
+
+EXPOSE 80


### PR DESCRIPTION
This uses multi-stage image build and this results in a huge image size shrink. Now the image is just ~25MB instead of almost 2GB as it now only includes the built and bundled version which should actually be used in production environments, instead of the git tree, node_modules and the built version
 